### PR TITLE
Quick and dirty removal of internal eigen build 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "external/pmp-data"]
 	path = external/pmp-data
 	url = https://github.com/pmp-library/pmp-data.git
-[submodule "external/eigen"]
-	path = external/eigen
-	url = https://gitlab.com/libeigen/eigen.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(PMP_BUILD_VIS)
 endif(PMP_BUILD_VIS)
 
 # setup Eigen
-set(EIGEN_SOURCE_DIR "external/eigen")
+set(EIGEN_SOURCE_DIR "/usr/local/include/eigen3/")
 include_directories(${EIGEN_SOURCE_DIR})
 
 # setup PLY


### PR DESCRIPTION
In favor of whatever's installed in /usr/local/include/eigen3. To avoid the dread multi-eigen issues.